### PR TITLE
fix: prevent --install-cert from truncating cert files to 0 bytes

### DIFF
--- a/enable-acme.sh
+++ b/enable-acme.sh
@@ -5,7 +5,7 @@
 # Thread: https://forum.gl-inet.com/t/script-lets-encrypt-for-gl-inet-router-https-access/41991
 # Author: Admon
 
-SCRIPT_VERSION="2026.04.24.03"
+SCRIPT_VERSION="2026.06.28.01"
 SCRIPT_NAME="enable-acme.sh"
 UPDATE_URL="https://get.admon.me/acme-update"
 REFLECTOR_URL="https://cgnat.admon.me/check?ports=80"

--- a/enable-acme.sh
+++ b/enable-acme.sh
@@ -14,6 +14,11 @@ ACME_SH_FALLBACK="/usr/lib/acme/acme.sh"
 ACME_SH="$ACME_SH_PRIMARY"
 ACME_HOME="/etc/acme"
 ACME_CERT_HOME="/etc/acme"
+# acme.sh's internal cert store. MUST be a different directory than the install
+# destinations below (/etc/acme/$DOMAIN). If they overlap, acme.sh's --install-cert
+# does `cat "$source" > "$dest"` where source and dest are the same file, which the
+# shell truncates to 0 bytes before reading -> empty cert files -> nginx won't start.
+ACME_INTERNAL_CERT_HOME="/etc/acme/.acme.sh"
 HAS_NGINX=0
 HAS_UHTTPD=0
 NGINX_CONFIG=""
@@ -139,8 +144,12 @@ issue_acme_cert() {
     
     # Create directories if they don't exist
     mkdir -p "$ACME_HOME"
+    # acme.sh's internal store (acme.sh also creates this itself during --issue)
+    mkdir -p "$ACME_INTERNAL_CERT_HOME/$DDNS_DOMAIN"
+    # Install destination for the webservers. acme.sh --install-cert does NOT
+    # create this directory, so it must exist before install_cert_to_webserver runs.
     mkdir -p "$ACME_CERT_HOME/$DDNS_DOMAIN"
-    
+
     # Issue certificate using acme.sh with Let's Encrypt
     "$ACME_SH" --issue \
         -d "$DDNS_DOMAIN" \
@@ -148,7 +157,7 @@ issue_acme_cert() {
         --keylength 2048 \
         --server letsencrypt \
         --home "$ACME_HOME" \
-        --cert-home "$ACME_CERT_HOME" \
+        --cert-home "$ACME_INTERNAL_CERT_HOME" \
         --httpport 80 \
         --force \
         --no-cron
@@ -446,7 +455,8 @@ install_cert_to_webserver() {
             --key-file "/etc/acme/$DDNS_DOMAIN/$DDNS_DOMAIN.key" \
             --fullchain-file "/etc/acme/$DDNS_DOMAIN/fullchain.cer" \
             --reloadcmd "/etc/init.d/nginx restart" \
-            --home "$ACME_HOME"
+            --home "$ACME_HOME" \
+            --cert-home "$ACME_INTERNAL_CERT_HOME"
         
         if [ $? -eq 0 ]; then
             sed -i "s|ssl_certificate .*;|ssl_certificate /etc/acme/$DDNS_DOMAIN/fullchain.cer;|g" "$NGINX_CONFIG"
@@ -467,7 +477,8 @@ install_cert_to_webserver() {
             --key-file "/etc/acme/$DDNS_DOMAIN/$DDNS_DOMAIN.key" \
             --fullchain-file "/etc/acme/$DDNS_DOMAIN/fullchain.cer" \
             --reloadcmd "/etc/init.d/uhttpd restart" \
-            --home "$ACME_HOME"
+            --home "$ACME_HOME" \
+            --cert-home "$ACME_INTERNAL_CERT_HOME"
         
         if [ $? -eq 0 ]; then
             uci set uhttpd.main.cert="/etc/acme/$DDNS_DOMAIN/fullchain.cer"
@@ -1021,6 +1032,8 @@ restore_configuration() {
         if [ -d "$ACME_CERT_HOME" ]; then
             rm -rf "${ACME_CERT_HOME:?}"/* 2>/dev/null || true
         fi
+        # The internal cert store is a hidden dir, so the glob above won't match it
+        rm -rf "${ACME_INTERNAL_CERT_HOME:?}" 2>/dev/null || true
         
         # Remove cronjob and wrapper script
         log "INFO" "Removing ACME cronjob"

--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,16 @@ Need assistance or have questions?
 
 ---
 
+## 🙌 Contributors
+
+Thanks to everyone who has helped improve this project:
+
+- [**tpak**](https://github.com/tpak) – Fixed `--install-cert` truncating certificate files to 0 bytes on routers where issuance succeeds ([#10](https://github.com/Admonstrator/glinet-enable-acme/pull/10), fixes [#8](https://github.com/Admonstrator/glinet-enable-acme/issues/8))
+
+Want to contribute? [Open an issue or pull request](https://github.com/Admonstrator/glinet-enable-acme/issues)!
+
+---
+
 ## ⚠️ Disclaimer
 
 This script is provided **as-is** without any warranty. Use it at your own risk.

--- a/readme.template.md
+++ b/readme.template.md
@@ -257,6 +257,16 @@ Need assistance or have questions?
 
 ---
 
+## 🙌 Contributors
+
+Thanks to everyone who has helped improve this project:
+
+- [**tpak**](https://github.com/tpak) – Fixed `--install-cert` truncating certificate files to 0 bytes on routers where issuance succeeds ([#10](https://github.com/Admonstrator/glinet-enable-acme/pull/10), fixes [#8](https://github.com/Admonstrator/glinet-enable-acme/issues/8))
+
+Want to contribute? [Open an issue or pull request](https://github.com/Admonstrator/glinet-enable-acme/issues)!
+
+---
+
 ## ⚠️ Disclaimer
 
 This script is provided **as-is** without any warranty. Use it at your own risk.


### PR DESCRIPTION
## Summary

Fixes #8

On routers where issuance succeeds (e.g. Flint 2 / GL-MT6000), the
installed certificate files are written **empty (0 bytes)**, so nginx and
uhttpd fail to start with errors like:

```
nginx: [emerg] cannot load certificate "/etc/acme/<domain>/fullchain.cer":
PEM_read_bio_X509_AUX() failed (... no start line: Expecting: TRUSTED CERTIFICATE)
```

This is the failure reported in #8 (and hit by myself and more than one Flint 2 user as reported). 

## Root cause

The script issues into acme.sh's internal store with `--cert-home /etc/acme`, so
the real cert files live at:

/etc/acme/<domain>/<domain>.cer
/etc/acme/<domain>/<domain>.key
/etc/acme/<domain>/fullchain.cer

`install_cert_to_webserver()` then runs `--install-cert` with
`--cert-file` / `--key-file` / `--fullchain-file` pointed at **those exact same
paths**. acme.sh installs with `cat "$source" > "$dest"`; when source and dest
are the same file, the shell truncates it to 0 bytes before `cat` reads it. All
three files end up empty, acme.sh still returns 0, the nginx config is rewritten
to point at the now-empty `fullchain.cer`, and this casues nginx and
uhttpd to error out.

## Fix

- Move acme.sh's internal store to a separate hidden dir
  (`ACME_INTERNAL_CERT_HOME=/etc/acme/.acme.sh`) so the install destinations
  under `/etc/acme/<domain>` no longer alias their own source files.
- Restore the `mkdir` for the install destination, which acme.sh `--install-cert`
  does not create on its own.
- Pass `--cert-home "$ACME_INTERNAL_CERT_HOME"` to `--install-cert` so it always
  reads from the store regardless of saved account state.
- In `--restore`, also remove the hidden store (the existing `/etc/acme/*` glob
  skips dotdirs).

Installed cert paths (`/etc/acme/<domain>/...`), nginx/uhttpd config rewrites,
persistence, and the outro messaging are all unchanged.

## Testing

Tested on a GL-MT6000 (Flint 2), firmware 4.9.0, with both nginx and uhttpd present:

- Certificate issues into `/etc/acme/.acme.sh/<domain>/` and installs to
  `/etc/acme/<domain>/` with **non-zero** `.cer` / `.key` / `fullchain.cer`.
- nginx and uhttpd restart cleanly; the GUI is reachable over HTTPS.
- `--restore` still reverts to the self-signed certs and cleans up the store.